### PR TITLE
Add Cloud Run GIF processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,34 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
   
 Optional (for Vercel deployments):
 - VERCEL_URL: Automatically provided by Vercel for building redirect URLs in password reset emails.
+
+## Cloud Run GIF Processor
+
+The `worker` directory contains a small service that polls the database for
+videos with a `processing` status and finalizes them. It checks the external
+video APIs, converts completed videos to GIFs and uploads them to Supabase
+storage. The main application no longer performs these steps; it simply polls
+its `/api/check-status` endpoint which now returns the latest database record.
+Run this worker in Cloud Run or locally alongside the Next.js app.
+
+Run locally:
+
+```bash
+npx ts-node worker/index.ts
+```
+
+Build the container for Cloud Run:
+
+```bash
+gcloud builds submit --tag gcr.io/<PROJECT-ID>/gif-worker -f worker/Dockerfile
+```
+
+Environment variables used by the worker:
+
+- `REPLICATE_API_TOKEN`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `DATABASE_URL`
+- `VIDEO_API_URL` and `VIDEO_API_TOKEN` (optional)
+- `VIDEO2GIF_API_KEY`
+- `POLL_INTERVAL_MS` (optional, defaults to `5000`)
+- `SUPABASE_GIFS_BUCKET_NAME` (optional)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build": "prisma generate && next build",
     "start": "next start -p 8080",
     "lint": "next lint",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "start:worker": "ts-node worker/index.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",

--- a/src/app/api/check-status/route.ts
+++ b/src/app/api/check-status/route.ts
@@ -1,377 +1,47 @@
 import { NextResponse } from 'next/server';
 import { createRouteHandlerSupabaseClient } from '@supabase/auth-helpers-nextjs';
 import { cookies, headers } from 'next/headers';
-import Replicate from 'replicate';
-
 import prisma from '@/lib/prisma';
-import { getSupabaseAdmin } from '@/lib/supabaseClient';
-import { randomUUID } from 'crypto';
 
-const replicate = new Replicate({
-  auth: process.env.REPLICATE_API_TOKEN || '',
-});
-
-// Supabase buckets (videos bucket unused in this handler)
-const GIFS_BUCKET = process.env.SUPABASE_GIFS_BUCKET_NAME || 'gifs';
 export async function GET(request: Request) {
-  // Initialize Supabase client for this route: await cookies() and headers() to avoid sync dynamic API usage
-  // Properly await cookies and headers to avoid sync dynamic API usage
-  const cookiesStore = await cookies();
-  const headersStore = await headers();
+  const cookieStore = await cookies();
+  const headerStore = await headers();
   const supabase = createRouteHandlerSupabaseClient({
-    cookies: () => cookiesStore,
-    headers: () => headersStore,
+    cookies: () => cookieStore,
+    headers: () => headerStore,
   });
+
   const {
     data: { session },
   } = await supabase.auth.getSession();
+
   if (!session?.user?.id) {
     return new NextResponse('Unauthorized', { status: 401 });
   }
   const userId = session.user.id;
 
-  // Get the videoId from the URL
   const { searchParams } = new URL(request.url);
   const videoId = searchParams.get('videoId');
-  
+
   if (!videoId) {
     return new NextResponse('Missing videoId', { status: 400 });
   }
 
   try {
-    // Get the video record
-    const video = await prisma.video.findUnique({
-      where: { id: videoId },
-    });
-
+    const video = await prisma.video.findUnique({ where: { id: videoId } });
     if (!video) {
       return new NextResponse('Video not found', { status: 404 });
     }
-    
-
-    // Check ownership
     if (video.userId !== userId) {
       return new NextResponse('Forbidden', { status: 403 });
     }
 
-    // If the video is already completed or failed, just return it
-    if (video.status === 'completed' || video.status === 'failed') {
-      return NextResponse.json(video);
-    }
-
-    // If no prediction ID, we can't check status
-    if (!video.replicatePredictionId) {
-      return NextResponse.json({
-        ...video,
-        error: 'No prediction ID available'
-      });
-    }
-    
-    // Attempt primary API status check
-    const PRIMARY_API_URL = process.env.VIDEO_API_URL;
-    const PRIMARY_API_TOKEN = process.env.VIDEO_API_TOKEN;
-    // Only use primary API for fast generation; slow uses Replicate only
-    if (video.type !== 'slow' && PRIMARY_API_URL && PRIMARY_API_TOKEN) {
-      try {
-        // Call primary API status endpoint
-        const statusRes = await fetch(
-          `${PRIMARY_API_URL.replace(/\/+$/, '')}/status/${video.replicatePredictionId}`,
-          {
-            method: 'GET',
-            headers: { Authorization: `Bearer ${PRIMARY_API_TOKEN}` },
-          }
-        );
-        if (!statusRes.ok) throw new Error(`Primary API status failed: ${statusRes.statusText}`);
-        const statusData = await statusRes.json();
-        const status = statusData.status;
-        if (status === 'done') {
-          // Construct the public/download URL for the generated video
-          const downloadUrl = `${PRIMARY_API_URL.replace(/\/+$/, '')}/download/${video.replicatePredictionId}`;
-          // Download video from primary API
-          const downloadRes = await fetch(downloadUrl, {
-            method: 'GET',
-            headers: { Authorization: `Bearer ${PRIMARY_API_TOKEN}` },
-          });
-          if (!downloadRes.ok) throw new Error(`Primary API download failed: ${downloadRes.statusText}`);
-          const videoData = await downloadRes.arrayBuffer();
-          // Upload video to external GIF conversion service
-          const supabaseAdmin = getSupabaseAdmin();
-          const apiKey = 'dabf5af2d8d1138dee335941f670a1c2a6218cd2197b95f2178d8d21247e8bc6';
-          const formData = new FormData();
-          formData.append('fps', '16');
-          formData.append(
-            'file',
-            new Blob([videoData], { type: 'video/mp4' }),
-            'video.mp4'
-          );
-          const createJobResponse = await fetch(
-            'https://video2gif-580559758743.us-central1.run.app/jobs',
-            {
-              method: 'POST',
-              headers: { 'X-API-KEY': apiKey },
-              body: formData,
-            }
-          );
-          if (!createJobResponse.ok) {
-            throw new Error(`Failed to create GIF job: ${createJobResponse.statusText}`);
-          }
-          const { job_id: jobId } = await createJobResponse.json();
-          // Poll for GIF conversion job status
-          let jobStatus = '';
-          do {
-            await new Promise((res) => setTimeout(res, 2000));
-            const statusResponse = await fetch(
-              `https://video2gif-580559758743.us-central1.run.app/jobs/${jobId}`,
-              { headers: { 'X-API-KEY': apiKey } }
-            );
-            if (!statusResponse.ok) {
-              throw new Error(`Failed to get job status: ${statusResponse.statusText}`);
-            }
-            const statusJson = await statusResponse.json();
-            jobStatus = statusJson.status;
-            if (jobStatus === 'failed') {
-              throw new Error('GIF conversion failed');
-            }
-          } while (jobStatus !== 'finished');
-          // Download the generated GIF
-          const gifResponse = await fetch(
-            `https://video2gif-580559758743.us-central1.run.app/jobs/${jobId}/gif`,
-            { headers: { 'X-API-KEY': apiKey } }
-          );
-          if (!gifResponse.ok) {
-            throw new Error(`Failed to download GIF: ${gifResponse.statusText}`);
-          }
-          const gifArrayBuffer = await gifResponse.arrayBuffer();
-          const gifBuffer = Buffer.from(gifArrayBuffer);
-          const gifFileName = `${video.userId}/${randomUUID()}.gif`;
-          const { error: gifsError } = await supabaseAdmin.storage
-            .from(GIFS_BUCKET)
-            .upload(gifFileName, gifBuffer, { contentType: 'image/gif' });
-          if (gifsError) {
-            throw new Error(`Supabase GIF upload error: ${gifsError.message}`);
-          }
-          const { data: gifUrlData } = await supabaseAdmin.storage
-            .from(GIFS_BUCKET)
-            .getPublicUrl(gifFileName);
-          if (!gifUrlData?.publicUrl) {
-            throw new Error('Could not get GIF public URL');
-          }
-          // Update video record with videoUrl and gifUrl
-          const updatedVideo = await prisma.video.update({
-            where: { id: videoId },
-            data: {
-              status: 'completed',
-              videoUrl: downloadUrl,
-              gifUrl: gifUrlData.publicUrl,
-            },
-          });
-          return NextResponse.json(updatedVideo);
-        } else if (status === 'failed') {
-          const updatedVideo = await prisma.video.update({
-            where: { id: videoId },
-            data: { status: 'failed' },
-          });
-          // Refund credits on failure
-          try {
-            const refundAmount = video.type === 'slow' ? 1 : 2;
-            await prisma.user.update({
-              where: { id: userId },
-              data: { credits: { increment: refundAmount } },
-            });
-          } catch (refundError) {
-            console.error("ERROR_REFUNDING_CREDITS", refundError);
-          }
-          return NextResponse.json(updatedVideo);
-        } else {
-          return NextResponse.json(video);
-        }
-      } catch (error) {
-        console.error('Primary API status error:', error);
-        // Fallback to Replicate
-      }
-    }
-
-    // Check prediction status
-    const prediction = await replicate.predictions.get(video.replicatePredictionId);
-    
-    // Update the video record based on the prediction status
-    if (prediction.status === 'succeeded') {
-      // Get the output URL from the prediction
-      const outputUrl = prediction.output;
-      
-      if (!outputUrl || (typeof outputUrl !== 'string' && !Array.isArray(outputUrl))) {
-        // Mark as failed if no output URL
-        await prisma.video.update({
-          where: { id: videoId },
-          data: { status: 'failed' },
-        });
-        // Refund credits on failure
-        try {
-          const refundAmount = video.type === 'slow' ? 1 : 2;
-          await prisma.user.update({
-            where: { id: userId },
-            data: { credits: { increment: refundAmount } },
-          });
-        } catch (refundError) {
-          console.error("ERROR_REFUNDING_CREDITS", refundError);
-        }
-        return NextResponse.json({
-          ...video,
-          status: 'failed',
-          error: 'No output URL from Replicate'
-        });
-      }
-
-      // Handle either string or array output
-      const videoUrl = typeof outputUrl === 'string' ? outputUrl : Array.isArray(outputUrl) ? outputUrl[0] : null;
-      
-      if (!videoUrl) {
-        await prisma.video.update({
-          where: { id: videoId },
-          data: { status: 'failed' },
-        });
-        // Refund credits on failure
-        try {
-          const refundAmount = video.type === 'slow' ? 1 : 2;
-          await prisma.user.update({
-            where: { id: userId },
-            data: { credits: { increment: refundAmount } },
-          });
-        } catch (refundError) {
-          console.error("ERROR_REFUNDING_CREDITS", refundError);
-        }
-        return NextResponse.json({
-          ...video,
-          status: 'failed',
-          error: 'Invalid output format from Replicate'
-        });
-      }
-
-      try {
-        // Download video from Replicate
-        const videoResponse = await fetch(videoUrl);
-        if (!videoResponse.ok) {
-          throw new Error(`Failed to download from ${videoUrl}: ${videoResponse.statusText}`);
-        }
-
-        const videoData = await videoResponse.arrayBuffer();
-
-        // Upload video to external GIF conversion service
-        const supabaseAdmin = getSupabaseAdmin();
-        const apiKey = 'dabf5af2d8d1138dee335941f670a1c2a6218cd2197b95f2178d8d21247e8bc6';
-        // Create GIF conversion job
-        const formData = new FormData();
-        formData.append('fps', '16');
-        formData.append('file', new Blob([videoData], { type: 'video/mp4' }), 'video.mp4');
-        const createJobResponse = await fetch(
-          'https://video2gif-580559758743.us-central1.run.app/jobs',
-          {
-            method: 'POST',
-            headers: { 'X-API-KEY': apiKey },
-            body: formData,
-          }
-        );
-        if (!createJobResponse.ok) {
-          throw new Error(`Failed to create GIF job: ${createJobResponse.statusText}`);
-        }
-        const { job_id: jobId } = await createJobResponse.json();
-        // Poll for job status
-        let jobStatus = '';
-        do {
-          await new Promise((res) => setTimeout(res, 2000));
-          const statusResponse = await fetch(
-            `https://video2gif-580559758743.us-central1.run.app/jobs/${jobId}`,
-            { headers: { 'X-API-KEY': apiKey } }
-          );
-          if (!statusResponse.ok) {
-            throw new Error(`Failed to get job status: ${statusResponse.statusText}`);
-          }
-          const statusJson = await statusResponse.json();
-          jobStatus = statusJson.status;
-          if (jobStatus === 'failed') {
-            throw new Error('GIF conversion failed');
-          }
-        } while (jobStatus !== 'finished');
-        // Download the generated GIF
-        const gifResponse = await fetch(
-          `https://video2gif-580559758743.us-central1.run.app/jobs/${jobId}/gif`,
-          { headers: { 'X-API-KEY': apiKey } }
-        );
-        if (!gifResponse.ok) {
-          throw new Error(`Failed to download GIF: ${gifResponse.statusText}`);
-        }
-        const gifArrayBuffer = await gifResponse.arrayBuffer();
-        const gifBuffer = Buffer.from(gifArrayBuffer);
-        // Upload GIF to Supabase
-        const gifFileName = `${video.userId}/${randomUUID()}.gif`;
-        const { error: gifsError } = await supabaseAdmin.storage
-          .from(GIFS_BUCKET)
-          .upload(gifFileName, gifBuffer, { contentType: 'image/gif' });
-        if (gifsError) {
-          throw new Error(`Supabase GIF upload error: ${gifsError.message}`);
-        }
-        const { data: gifUrlData } = await supabaseAdmin.storage
-          .from(GIFS_BUCKET)
-          .getPublicUrl(gifFileName);
-        if (!gifUrlData?.publicUrl) {
-          throw new Error('Could not get GIF public URL');
-        }
-        // Update video record with videoUrl and gifUrl
-        const updatedVideo = await prisma.video.update({
-          where: { id: videoId },
-          data: {
-            status: 'completed',
-            videoUrl: videoUrl,
-            gifUrl: gifUrlData.publicUrl,
-          },
-        });
-        return NextResponse.json(updatedVideo);
-        
-      } catch (error) {
-        console.error('Error processing completed prediction:', error);
-        await prisma.video.update({
-          where: { id: videoId },
-          data: { status: 'failed' },
-        });
-        // Refund credits on failure
-        try {
-          const refundAmount = video.type === 'slow' ? 1 : 2;
-          await prisma.user.update({
-            where: { id: userId },
-            data: { credits: { increment: refundAmount } },
-          });
-        } catch (refundError) {
-          console.error("ERROR_REFUNDING_CREDITS", refundError);
-        }
-        return NextResponse.json({
-          ...video,
-          status: 'failed',
-          error: error instanceof Error ? error.message : 'Unknown error processing video'
-        });
-      }
-    } else if (prediction.status === 'failed') {
-      // Update to failed status
-      const updatedVideo = await prisma.video.update({
-        where: { id: videoId },
-        data: { status: 'failed' },
-      });
-      // Refund credits on failure
-      try {
-        const refundAmount = video.type === 'slow' ? 1 : 2;
-        await prisma.user.update({
-          where: { id: userId },
-          data: { credits: { increment: refundAmount } },
-        });
-      } catch (refundError) {
-        console.error("ERROR_REFUNDING_CREDITS", refundError);
-      }
-      return NextResponse.json(updatedVideo);
-    } else {
-      // Still processing
-      return NextResponse.json(video);
-    }
+    return NextResponse.json(video);
   } catch (error) {
     console.error('Error in check-status:', error);
-    return new NextResponse(error instanceof Error ? error.message : 'Error checking status', { status: 500 });
+    return new NextResponse(
+      error instanceof Error ? error.message : 'Error checking status',
+      { status: 500 }
+    );
   }
-} 
+}

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /usr/src/app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+CMD ["npx", "ts-node", "worker/index.ts"]

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,0 +1,149 @@
+import Replicate from 'replicate';
+import prisma from '../src/lib/prisma';
+import { getSupabaseAdmin } from '../src/lib/supabaseClient';
+import { randomUUID } from 'crypto';
+
+const replicate = new Replicate({ auth: process.env.REPLICATE_API_TOKEN || '' });
+
+const GIFS_BUCKET = process.env.SUPABASE_GIFS_BUCKET_NAME || 'gifs';
+const PRIMARY_API_URL = process.env.VIDEO_API_URL;
+const PRIMARY_API_TOKEN = process.env.VIDEO_API_TOKEN;
+const VIDEO2GIF_API_KEY = process.env.VIDEO2GIF_API_KEY || 'dabf5af2d8d1138dee335941f670a1c2a6218cd2197b95f2178d8d21247e8bc6';
+const POLL_INTERVAL_MS = parseInt(process.env.POLL_INTERVAL_MS || '5000', 10);
+
+async function sleep(ms: number) {
+  return new Promise(res => setTimeout(res, ms));
+}
+
+async function refundCredits(userId: string, type: string) {
+  try {
+    const amount = type === 'slow' ? 1 : 2;
+    await prisma.user.update({
+      where: { id: userId },
+      data: { credits: { increment: amount } },
+    });
+  } catch (err) {
+    console.error('ERROR_REFUNDING_CREDITS', err);
+  }
+}
+
+async function uploadGif(userId: string, gifBuffer: Buffer) {
+  const supabase = getSupabaseAdmin();
+  const gifFileName = `${userId}/${randomUUID()}.gif`;
+  const { error } = await supabase.storage
+    .from(GIFS_BUCKET)
+    .upload(gifFileName, gifBuffer, { contentType: 'image/gif' });
+  if (error) throw new Error(`Supabase GIF upload error: ${error.message}`);
+  const { data } = await supabase.storage.from(GIFS_BUCKET).getPublicUrl(gifFileName);
+  if (!data?.publicUrl) throw new Error('Could not get GIF public URL');
+  return data.publicUrl;
+}
+
+async function convertVideoToGif(videoData: ArrayBuffer): Promise<Buffer> {
+  const formData = new FormData();
+  formData.append('fps', '16');
+  formData.append('file', new Blob([videoData], { type: 'video/mp4' }), 'video.mp4');
+  const createRes = await fetch('https://video2gif-580559758743.us-central1.run.app/jobs', {
+    method: 'POST',
+    headers: { 'X-API-KEY': VIDEO2GIF_API_KEY },
+    body: formData,
+  });
+  if (!createRes.ok) throw new Error(`Failed to create GIF job: ${createRes.statusText}`);
+  const { job_id: jobId } = await createRes.json();
+  let status = '';
+  do {
+    await sleep(2000);
+    const statusRes = await fetch(`https://video2gif-580559758743.us-central1.run.app/jobs/${jobId}`, {
+      headers: { 'X-API-KEY': VIDEO2GIF_API_KEY },
+    });
+    if (!statusRes.ok) throw new Error(`Failed to get job status: ${statusRes.statusText}`);
+    const js = await statusRes.json();
+    status = js.status;
+    if (status === 'failed') throw new Error('GIF conversion failed');
+  } while (status !== 'finished');
+  const gifRes = await fetch(`https://video2gif-580559758743.us-central1.run.app/jobs/${jobId}/gif`, {
+    headers: { 'X-API-KEY': VIDEO2GIF_API_KEY },
+  });
+  if (!gifRes.ok) throw new Error(`Failed to download GIF: ${gifRes.statusText}`);
+  const buf = Buffer.from(await gifRes.arrayBuffer());
+  return buf;
+}
+
+async function handleVideoCompletion(video: any, videoUrl: string) {
+  const videoRes = await fetch(videoUrl);
+  if (!videoRes.ok) throw new Error(`Failed to download ${videoUrl}: ${videoRes.statusText}`);
+  const videoData = await videoRes.arrayBuffer();
+  const gifBuffer = await convertVideoToGif(videoData);
+  const gifUrl = await uploadGif(video.userId, gifBuffer);
+  await prisma.video.update({
+    where: { id: video.id },
+    data: { status: 'completed', videoUrl, gifUrl },
+  });
+  console.log(`Video ${video.id} completed`);
+}
+
+async function processVideo(video: any) {
+  if (!video.replicatePredictionId) return;
+
+  // primary API path for fast generation
+  if (video.type !== 'slow' && PRIMARY_API_URL && PRIMARY_API_TOKEN) {
+    try {
+      const statusRes = await fetch(`${PRIMARY_API_URL.replace(/\/+$/, '')}/status/${video.replicatePredictionId}`, {
+        headers: { Authorization: `Bearer ${PRIMARY_API_TOKEN}` },
+      });
+      if (!statusRes.ok) throw new Error(`Primary status error: ${statusRes.statusText}`);
+      const statusData = await statusRes.json();
+      const status = statusData.status;
+      if (status === 'done') {
+        const downloadUrl = `${PRIMARY_API_URL.replace(/\/+$/, '')}/download/${video.replicatePredictionId}`;
+        const downloadRes = await fetch(downloadUrl, {
+          headers: { Authorization: `Bearer ${PRIMARY_API_TOKEN}` },
+        });
+        if (!downloadRes.ok) throw new Error(`Primary download error: ${downloadRes.statusText}`);
+        const videoData = await downloadRes.arrayBuffer();
+        const gifBuffer = await convertVideoToGif(videoData);
+        const gifUrl = await uploadGif(video.userId, gifBuffer);
+        await prisma.video.update({
+          where: { id: video.id },
+          data: { status: 'completed', videoUrl: downloadUrl, gifUrl },
+        });
+        console.log(`Video ${video.id} completed via primary API`);
+        return;
+      } else if (status === 'failed') {
+        await prisma.video.update({ where: { id: video.id }, data: { status: 'failed' } });
+        await refundCredits(video.userId, video.type);
+        return;
+      }
+    } catch (err) {
+      console.error('Primary API error', err);
+    }
+  }
+
+  // replicate fallback
+  try {
+    const prediction = await replicate.predictions.get(video.replicatePredictionId);
+    if (prediction.status === 'succeeded') {
+      const outputUrl = prediction.output;
+      const videoUrl = typeof outputUrl === 'string' ? outputUrl : Array.isArray(outputUrl) ? outputUrl[0] : null;
+      if (!videoUrl) throw new Error('No video URL from Replicate');
+      await handleVideoCompletion(video, videoUrl);
+    } else if (prediction.status === 'failed') {
+      await prisma.video.update({ where: { id: video.id }, data: { status: 'failed' } });
+      await refundCredits(video.userId, video.type);
+    }
+  } catch (err) {
+    console.error('Replicate error', err);
+  }
+}
+
+async function pollLoop() {
+  while (true) {
+    const videos = await prisma.video.findMany({ where: { status: 'processing' }, take: 5 });
+    for (const v of videos) {
+      await processVideo(v);
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+}
+
+pollLoop().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- add `worker` directory with a polling service for processing videos
- document new worker in README
- add script `start:worker`
- simplify `/api/check-status` endpoint to only return video status

## Testing
- `npm run lint` *(fails: `next: not found`)*