### PR TITLE
Add Cloud Run worker deployment helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,39 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
   
 Optional (for Vercel deployments):
 - VERCEL_URL: Automatically provided by Vercel for building redirect URLs in password reset emails.
+
+## Cloud Run GIF Processor
+
+The `worker` directory contains a small service that polls the database for
+videos with `processing` status and finalizes them. It checks the external video
+APIs, converts completed videos to GIFs and uploads them to Supabase storage.
+This worker can be deployed to Google Cloud Run.
+
+Run locally:
+
+```bash
+npx ts-node worker/index.ts
+```
+
+Build the container for Cloud Run:
+
+```bash
+gcloud builds submit --tag gcr.io/<PROJECT-ID>/gif-worker -f worker/Dockerfile
+```
+
+Environment variables used by the worker:
+
+- `REPLICATE_API_TOKEN`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `DATABASE_URL`
+- `VIDEO_API_URL` and `VIDEO_API_TOKEN` (optional)
+- `VIDEO2GIF_API_KEY`
+- `POLL_INTERVAL_MS` (optional, defaults to `5000`)
+- `SUPABASE_GIFS_BUCKET_NAME` (optional)
+
+A sample environment file is provided at `worker/env.yaml`. After building the
+container, deploy the worker with:
+
+```bash
+./deploy-worker.sh
+```

--- a/deploy-worker.sh
+++ b/deploy-worker.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Deploy the GIF worker to Google Cloud Run
+set -euo pipefail
+
+gcloud run deploy gif-worker \
+  --project diffusion-453104 \
+  --region us-central1 \
+  --image gcr.io/diffusion-453104/gif-worker \
+  --env-vars-file worker/env.yaml

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "build": "prisma generate && next build",
     "start": "next start -p 8080",
     "lint": "next lint",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "start:worker": "ts-node worker/index.ts",
+    "deploy:worker": "bash deploy-worker.sh"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /usr/src/app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+CMD ["npx", "ts-node", "worker/index.ts"]

--- a/worker/env.yaml
+++ b/worker/env.yaml
@@ -1,0 +1,8 @@
+REPLICATE_API_TOKEN: "<replicate-token>"
+SUPABASE_SERVICE_ROLE_KEY: "<supabase-service-role-key>"
+DATABASE_URL: "<database-url>"
+VIDEO_API_URL: "<primary-api-url>"
+VIDEO_API_TOKEN: "<primary-api-token>"
+VIDEO2GIF_API_KEY: "<video2gif-api-key>"
+POLL_INTERVAL_MS: "5000"
+SUPABASE_GIFS_BUCKET_NAME: "gifs"

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,0 +1,149 @@
+import Replicate from 'replicate';
+import prisma from '../src/lib/prisma';
+import { getSupabaseAdmin } from '../src/lib/supabaseClient';
+import { randomUUID } from 'crypto';
+
+const replicate = new Replicate({ auth: process.env.REPLICATE_API_TOKEN || '' });
+
+const GIFS_BUCKET = process.env.SUPABASE_GIFS_BUCKET_NAME || 'gifs';
+const PRIMARY_API_URL = process.env.VIDEO_API_URL;
+const PRIMARY_API_TOKEN = process.env.VIDEO_API_TOKEN;
+const VIDEO2GIF_API_KEY = process.env.VIDEO2GIF_API_KEY || '';
+const POLL_INTERVAL_MS = parseInt(process.env.POLL_INTERVAL_MS || '5000', 10);
+
+async function sleep(ms: number) {
+  return new Promise(res => setTimeout(res, ms));
+}
+
+async function refundCredits(userId: string, type: string) {
+  try {
+    const amount = type === 'slow' ? 1 : 2;
+    await prisma.user.update({
+      where: { id: userId },
+      data: { credits: { increment: amount } },
+    });
+  } catch (err) {
+    console.error('ERROR_REFUNDING_CREDITS', err);
+  }
+}
+
+async function uploadGif(userId: string, gifBuffer: Buffer) {
+  const supabase = getSupabaseAdmin();
+  const gifFileName = `${userId}/${randomUUID()}.gif`;
+  const { error } = await supabase.storage
+    .from(GIFS_BUCKET)
+    .upload(gifFileName, gifBuffer, { contentType: 'image/gif' });
+  if (error) throw new Error(`Supabase GIF upload error: ${error.message}`);
+  const { data } = await supabase.storage.from(GIFS_BUCKET).getPublicUrl(gifFileName);
+  if (!data?.publicUrl) throw new Error('Could not get GIF public URL');
+  return data.publicUrl;
+}
+
+async function convertVideoToGif(videoData: ArrayBuffer): Promise<Buffer> {
+  const formData = new FormData();
+  formData.append('fps', '16');
+  formData.append('file', new Blob([videoData], { type: 'video/mp4' }), 'video.mp4');
+  const createRes = await fetch('https://video2gif-580559758743.us-central1.run.app/jobs', {
+    method: 'POST',
+    headers: { 'X-API-KEY': VIDEO2GIF_API_KEY },
+    body: formData,
+  });
+  if (!createRes.ok) throw new Error(`Failed to create GIF job: ${createRes.statusText}`);
+  const { job_id: jobId } = await createRes.json();
+  let status = '';
+  do {
+    await sleep(2000);
+    const statusRes = await fetch(`https://video2gif-580559758743.us-central1.run.app/jobs/${jobId}`, {
+      headers: { 'X-API-KEY': VIDEO2GIF_API_KEY },
+    });
+    if (!statusRes.ok) throw new Error(`Failed to get job status: ${statusRes.statusText}`);
+    const js = await statusRes.json();
+    status = js.status;
+    if (status === 'failed') throw new Error('GIF conversion failed');
+  } while (status !== 'finished');
+  const gifRes = await fetch(`https://video2gif-580559758743.us-central1.run.app/jobs/${jobId}/gif`, {
+    headers: { 'X-API-KEY': VIDEO2GIF_API_KEY },
+  });
+  if (!gifRes.ok) throw new Error(`Failed to download GIF: ${gifRes.statusText}`);
+  const buf = Buffer.from(await gifRes.arrayBuffer());
+  return buf;
+}
+
+async function handleVideoCompletion(video: any, videoUrl: string) {
+  const videoRes = await fetch(videoUrl);
+  if (!videoRes.ok) throw new Error(`Failed to download ${videoUrl}: ${videoRes.statusText}`);
+  const videoData = await videoRes.arrayBuffer();
+  const gifBuffer = await convertVideoToGif(videoData);
+  const gifUrl = await uploadGif(video.userId, gifBuffer);
+  await prisma.video.update({
+    where: { id: video.id },
+    data: { status: 'completed', videoUrl, gifUrl },
+  });
+  console.log(`Video ${video.id} completed`);
+}
+
+async function processVideo(video: any) {
+  if (!video.replicatePredictionId) return;
+
+  // primary API path for fast generation
+  if (video.type !== 'slow' && PRIMARY_API_URL && PRIMARY_API_TOKEN) {
+    try {
+      const statusRes = await fetch(`${PRIMARY_API_URL.replace(/\/+$/, '')}/status/${video.replicatePredictionId}`, {
+        headers: { Authorization: `Bearer ${PRIMARY_API_TOKEN}` },
+      });
+      if (!statusRes.ok) throw new Error(`Primary status error: ${statusRes.statusText}`);
+      const statusData = await statusRes.json();
+      const status = statusData.status;
+      if (status === 'done') {
+        const downloadUrl = `${PRIMARY_API_URL.replace(/\/+$/, '')}/download/${video.replicatePredictionId}`;
+        const downloadRes = await fetch(downloadUrl, {
+          headers: { Authorization: `Bearer ${PRIMARY_API_TOKEN}` },
+        });
+        if (!downloadRes.ok) throw new Error(`Primary download error: ${downloadRes.statusText}`);
+        const videoData = await downloadRes.arrayBuffer();
+        const gifBuffer = await convertVideoToGif(videoData);
+        const gifUrl = await uploadGif(video.userId, gifBuffer);
+        await prisma.video.update({
+          where: { id: video.id },
+          data: { status: 'completed', videoUrl: downloadUrl, gifUrl },
+        });
+        console.log(`Video ${video.id} completed via primary API`);
+        return;
+      } else if (status === 'failed') {
+        await prisma.video.update({ where: { id: video.id }, data: { status: 'failed' } });
+        await refundCredits(video.userId, video.type);
+        return;
+      }
+    } catch (err) {
+      console.error('Primary API error', err);
+    }
+  }
+
+  // replicate fallback
+  try {
+    const prediction = await replicate.predictions.get(video.replicatePredictionId);
+    if (prediction.status === 'succeeded') {
+      const outputUrl = prediction.output;
+      const videoUrl = typeof outputUrl === 'string' ? outputUrl : Array.isArray(outputUrl) ? outputUrl[0] : null;
+      if (!videoUrl) throw new Error('No video URL from Replicate');
+      await handleVideoCompletion(video, videoUrl);
+    } else if (prediction.status === 'failed') {
+      await prisma.video.update({ where: { id: video.id }, data: { status: 'failed' } });
+      await refundCredits(video.userId, video.type);
+    }
+  } catch (err) {
+    console.error('Replicate error', err);
+  }
+}
+
+async function pollLoop() {
+  while (true) {
+    const videos = await prisma.video.findMany({ where: { status: 'processing' }, take: 5 });
+    for (const v of videos) {
+      await processVideo(v);
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+}
+
+pollLoop().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- add example environment file at `worker/env.yaml`
- add `deploy-worker.sh` for Cloud Run deploy command
- document worker deployment in README
- remove hard-coded default `VIDEO2GIF_API_KEY`
- expose `npm run deploy:worker` script

## Testing
- `npm run lint` *(fails: `next: not found`)*