### PR TITLE
Add sample steps to fast replicate generation

### DIFF
--- a/src/app/api/generate-video/route.ts
+++ b/src/app/api/generate-video/route.ts
@@ -250,7 +250,7 @@ export async function POST(request: Request) {
     // Use version field for Replicate API (required by HTTP API)
     const prediction = await replicate.predictions.create({
       version: REPLICATE_MODEL_VERSION,
-      input: { image: signedUrl ?? imageUrl, prompt: effectivePrompt },
+      input: { image: signedUrl ?? imageUrl, prompt: effectivePrompt, sample_steps: 40 },
     });
     if (!prediction?.id) {
       throw new Error("Failed to create Replicate prediction.");


### PR DESCRIPTION
## Summary
- include `sample_steps: 40` for the fast Replicate prediction
- keep the slow Replicate model unchanged

## Testing
- `npm run lint` *(fails: next not found)*
