### PR TITLE
Add sample steps to replicate video generation

### DIFF
--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { createRouteHandlerSupabaseClient } from '@supabase/auth-helpers-nextjs';
 import { cookies, headers } from 'next/headers';
 import prisma from '@/lib/prisma';
+import type { Prisma } from '@prisma/client';
 
 export async function GET(request: Request) {
   try {
@@ -40,7 +41,7 @@ export async function GET(request: Request) {
         isAdmin: true,
         createdAt: true,
       },
-      orderBy: { [sortField]: order } as any,
+      orderBy: { [sortField]: order } as Prisma.UserOrderByWithRelationInput,
     });
     return NextResponse.json(users);
   } catch (error) {

--- a/src/app/api/generate-video/route.ts
+++ b/src/app/api/generate-video/route.ts
@@ -168,16 +168,17 @@ export async function POST(request: Request) {
     // If using Slow and Good option, skip primary API and use slow Replicate model
     if (generationType === 'slow') {
       // Start an asynchronous prediction with the slow model
-      const prediction = await replicate.predictions.create({
-        version: SLOW_REPLICATE_MODEL_VERSION,
-        input: {
-          prompt: effectivePrompt,
-          duration: 4,
-          aspect_ratio: "16:9",
-          frame_image_url: signedUrl ?? imageUrl,
-          use_prompt_enhancer: enhancePrompt,
-        },
-      });
+        const prediction = await replicate.predictions.create({
+          version: SLOW_REPLICATE_MODEL_VERSION,
+          input: {
+            prompt: effectivePrompt,
+            duration: 4,
+            aspect_ratio: "16:9",
+            frame_image_url: signedUrl ?? imageUrl,
+            use_prompt_enhancer: enhancePrompt,
+            sample_steps: 40,
+          },
+        });
       if (!prediction?.id) {
         throw new Error("Failed to create Replicate prediction.");
       }
@@ -250,7 +251,7 @@ export async function POST(request: Request) {
     // Use version field for Replicate API (required by HTTP API)
     const prediction = await replicate.predictions.create({
       version: REPLICATE_MODEL_VERSION,
-      input: { image: signedUrl ?? imageUrl, prompt: effectivePrompt },
+      input: { image: signedUrl ?? imageUrl, prompt: effectivePrompt, sample_steps: 40 },
     });
     if (!prediction?.id) {
       throw new Error("Failed to create Replicate prediction.");

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -1,5 +1,5 @@
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
-import { AuthOptions } from "next-auth";
+import type { AuthOptions, User as NextAuthUser } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import bcrypt from "bcrypt";
 
@@ -47,7 +47,7 @@ export const authOptions: AuthOptions = {
           isAdmin: Boolean(userWithoutPassword.isAdmin),
         };
         // Return as NextAuth User
-        return safeUser as any;
+        return safeUser as NextAuthUser;
       },
     }),
     // You can add more OAuth providers here in the future
@@ -85,7 +85,7 @@ export const authOptions: AuthOptions = {
             token.credits = user.credits as number;
           }
           if ('isAdmin' in user) {
-            token.isAdmin = Boolean((user as any).isAdmin);
+            token.isAdmin = Boolean((user as NextAuthUser).isAdmin);
           }
           return token;
         }


### PR DESCRIPTION
## Summary
- set `sample_steps: 40` when calling the slow Replicate model
- set `sample_steps: 40` for the fallback Replicate generation
- fix lint errors

## Testing
- `npm run lint`