### PR TITLE
Add Supabase auth middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,10 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
   
 Optional (for Vercel deployments):
 - VERCEL_URL: Automatically provided by Vercel for building redirect URLs in password reset emails.
+
+## Authentication Notes
+
+This project uses Supabase Auth for user management. A `middleware.ts` file is
+included which calls `supabase.auth.getSession()` on every request. This ensures
+expired access tokens are automatically refreshed so users stay logged in while
+browsing the site.

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { createMiddlewareSupabaseClient } from '@supabase/auth-helpers-nextjs';
+
+export async function middleware(req: NextRequest) {
+  const res = NextResponse.next();
+  const supabase = createMiddlewareSupabaseClient({ req, res });
+  // This will refresh auth tokens if they've expired - ensuring the user
+  // session stays valid across navigation.
+  await supabase.auth.getSession();
+  return res;
+}
+
+// Apply to all paths except Next.js internals and public files
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+};


### PR DESCRIPTION
## Summary
- keep users logged in by adding Supabase auth middleware
- document middleware usage

## Testing
- `npm run lint`
- `npm run build` *(fails: `Failed to fetch Inter from Google Fonts`)*