### PR TITLE
Disable sign ups and credit purchases

### DIFF
--- a/src/app/credits/cancel/page.tsx
+++ b/src/app/credits/cancel/page.tsx
@@ -15,15 +15,9 @@ function CancelContent() {
             Payment Cancelled
           </h2>
           <p className="text-gray-600 text-center">
-            Your credit purchase was cancelled. No payment has been processed.
+            Credit purchases are currently unavailable. If you need assistance, please contact support and reference your payment attempt.
           </p>
           <div className="pt-4 space-y-3">
-            <Link
-              href="/credits"
-              className="block w-full py-3 px-6 rounded-xl text-sm font-medium text-white bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF] hover:opacity-90 transition"
-            >
-              Try Again
-            </Link>
             <Link
               href="/"
               className="block w-full py-3 px-6 border border-gray-600 text-gray-300 text-center rounded-xl hover:bg-[#1A1A1D] transition"

--- a/src/app/credits/page.tsx
+++ b/src/app/credits/page.tsx
@@ -1,178 +1,89 @@
 'use client';
 
-import { useState } from 'react';
 import useSWR from 'swr';
-import { useRouter } from 'next/navigation';
-import { Zap, AlertCircle, CreditCard, Loader2 } from 'lucide-react';
-import { CREDIT_PACKAGES } from '@/lib/stripe';
 import Link from 'next/link';
-import toast from 'react-hot-toast';
+import { AlertCircle, Zap } from 'lucide-react';
+
+interface UserResponse {
+  credits?: number;
+}
+
+const fetcher = (url: string) =>
+  fetch(url, { credentials: 'include' }).then(res => {
+    if (!res.ok) {
+      throw new Error('Unauthorized');
+    }
+    return res.json();
+  });
 
 export default function CreditsPage() {
-  const fetcher = (url: string) =>
-    fetch(url, { credentials: 'include' }).then(res => {
-      if (!res.ok) throw new Error('Unauthorized');
-      return res.json();
-    });
-  const { data: user, error: authError, isLoading: authLoading } = useSWR('/api/user', fetcher);
-  const router = useRouter();
-  const [selectedPackage, setSelectedPackage] = useState(CREDIT_PACKAGES[0].id);
-  const [isLoading, setIsLoading] = useState(false);
-
-  const handlePurchase = async () => {
-    if (!user) {
-      toast.error('You must be signed in to purchase credits');
-      router.push('/login');
-      return;
-    }
-
-    // Find the selected package
-    const packageToCheckout = CREDIT_PACKAGES.find(pkg => pkg.id === selectedPackage);
-    if (!packageToCheckout) {
-      toast.error('Invalid package selection');
-      return;
-    }
-
-    setIsLoading(true);
-    try {
-      const response = await fetch('/api/checkout', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          packageId: selectedPackage,
-        }),
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || 'Failed to create checkout session');
-      }
-
-      // Redirect to Stripe checkout
-      window.location.href = data.url;
-    } catch (error) {
-      console.error('Error creating checkout session:', error);
-      toast.error('Failed to process payment request');
-      setIsLoading(false);
-    }
-  };
-
-  // Format price as currency
-  const formatPrice = (price: number): string => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
-    }).format(price / 100);
-  };
-
-  // Show loading state while checking authentication
-  if (authLoading) {
-    return (
-      <div className="flex justify-center items-center h-screen bg-[#0D0D0E]">
-        <Loader2 className="animate-spin h-8 w-8 text-[#3EFFE2]" />
-      </div>
-    );
-  }
-
-  // Show sign-in prompt for unauthenticated users
-  if (authError) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-screen bg-[#0D0D0E] p-4">
-        <div className="bg-[#1A1A1D] rounded-2xl shadow-lg p-8 border border-gray-800 text-center w-full max-w-md">
-          <AlertCircle className="mx-auto text-[#3EFFE2] h-16 w-16 mb-4" />
-          <h1 className="text-3xl font-extrabold mb-4 text-transparent bg-clip-text bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF]">
-            Sign In Required
-          </h1>
-          <p className="text-gray-300 mb-6">
-            You need to be signed in to purchase credits.
-          </p>
-          <Link
-            href="/login"
-            className="inline-block px-6 py-3 rounded-xl text-sm font-medium text-white bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF] hover:opacity-90 transition"
-          >
-            Sign In
-          </Link>
-        </div>
-      </div>
-    );
-  }
+  const { data: user, error, isLoading } = useSWR<UserResponse>('/api/user', fetcher, {
+    shouldRetryOnError: false,
+  });
 
   return (
-  <div className="container mx-auto max-w-4xl px-4 py-8">
-    <h1 className="text-4xl font-extrabold mb-6 text-transparent bg-clip-text bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF]">
-      Purchase Credits
-    </h1>
-      
-      <div className="bg-[#1A1A1D] rounded-2xl shadow-xl overflow-hidden border border-gray-800">
-        <div className="p-6">
-          <div className="flex items-center mb-6">
-            <Zap className="h-8 w-8 text-[#3EFFE2] mr-3" />
-            <div>
-              <h2 className="text-xl font-semibold text-white">Buy Credits</h2>
-              <p className="text-gray-300">Credits are used to generate GIFs</p>
+    <div className="min-h-screen bg-[#0D0D0E] py-16 px-4">
+      <div className="max-w-3xl mx-auto">
+        <div className="bg-[#1A1A1D] rounded-3xl border border-gray-800 shadow-xl overflow-hidden">
+          <div className="p-8 space-y-6">
+            <div className="flex items-center gap-3">
+              <AlertCircle className="h-10 w-10 text-[#FF497D]" />
+              <div>
+                <h1 className="text-3xl font-bold text-white">Credit purchases unavailable</h1>
+                <p className="text-gray-300">
+                  Buying additional credits is temporarily disabled. You can continue creating GIFs with your existing balance.
+                </p>
+              </div>
             </div>
-          </div>
 
-          <div className="grid gap-4 md:grid-cols-3 mb-8">
-            {CREDIT_PACKAGES.map((pkg) => (
-              <div
-                key={pkg.id}
-                onClick={() => setSelectedPackage(pkg.id)}
-                className={`cursor-pointer transition-all rounded-2xl p-4 border ${
-                  selectedPackage === pkg.id
-                    ? 'border-[#FF497D] bg-[#1A1A1D] shadow-xl'
-                    : 'border-gray-600 bg-[#1A1A1D]/70 hover:border-gray-500 hover:bg-[#1A1A1D] hover:shadow-lg'
-                }`}
-              >
-                <div className="flex flex-col h-full">
-                  <h3 className="font-semibold text-lg text-white">{pkg.name}</h3>
-                  <div className="my-2 text-3xl font-bold text-white">{formatPrice(pkg.price)}</div>
-                  <p className="text-gray-300 text-sm mb-4">
-                    {pkg.credits} credits to generate GIFs
-                  </p>
-                  <div className="mt-auto">
-                    <div
-                      className={`h-5 w-5 rounded-full border-2 ml-auto ${
-                        selectedPackage === pkg.id ? 'border-[#FF497D] bg-[#FF497D]' : 'border-gray-500'
-                      }`}
-                    />
-                  </div>
+            <div className="rounded-2xl border border-[#2A2A2D] bg-[#0D0D0E] p-6 space-y-4">
+              <div className="flex items-center gap-3">
+                <div className="h-12 w-12 rounded-full bg-[#1A1A1D] flex items-center justify-center">
+                  <Zap className="h-6 w-6 text-[#3EFFE2]" />
+                </div>
+                <div>
+                  <p className="text-gray-300">Current credit balance</p>
+                  {isLoading ? (
+                    <p className="text-white font-semibold">Checking balance...</p>
+                  ) : error ? (
+                    <p className="text-gray-500">Sign in to view your available credits.</p>
+                  ) : (
+                    <p className="text-white text-2xl font-bold">{user?.credits ?? 0} credits</p>
+                  )}
                 </div>
               </div>
-            ))}
-          </div>
-
-          <div className="flex justify-between items-center p-4 bg-[#0D0D0E]  rounded-lg mb-6">
-            <div>
-              <p className="text-gray-300 font-medium">Current balance</p>
-            <p className="text-2xl font-bold text-white">{user?.credits || 0} credits</p>
+              {error && (
+                <Link
+                  href="/login"
+                  className="inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-medium text-white bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF] hover:opacity-90 transition"
+                >
+                  Sign in to view balance
+                </Link>
+              )}
             </div>
-            <button
-              onClick={handlePurchase}
-              disabled={isLoading}
-              className="px-6 py-3 rounded-xl text-white bg-[#2A2A2D] hover:bg-[#3A3A3D] transition flex items-center space-x-2 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              <CreditCard className="h-5 w-5" />
-              <span>{isLoading ? 'Processing...' : 'Purchase Now'}</span>
-            </button>
-          </div>
 
-          <div className="text-sm text-gray-300">
-            <h3 className="font-medium text-gray-200 mb-2">How credits work:</h3>
-            <ul className="list-disc pl-5 space-y-1">
-              <li><span className="bg-clip-text text-transparent bg-gradient-to-r from-[#3EFFE2] to-[#3EFFE2]">Pro</span> GIF generation costs 1 credit</li>
-              <li><span className="bg-clip-text text-transparent bg-gradient-to-r from-[#1E3AFF] to-[#1E3AFF]">Standard</span> GIF generation costs 2 credits</li>
-              <li><span className="bg-clip-text text-transparent bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF]">Premium</span> GIF generation costs 3 credits</li>
-              <li>Credits never expire</li>
-              <li>Payment is processed securely through Stripe</li>
-              <li>We don&apos;t store your payment information</li>
-            </ul>
+            <div className="space-y-3 text-gray-400">
+              <p>
+                We&apos;re working on improvements to the credit system. In the meantime, feel free to explore your gallery or start a new project with the credits you already have.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-3">
+                <Link
+                  href="/gallery"
+                  className="flex-1 inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-medium text-white bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF] hover:opacity-90 transition"
+                >
+                  Go to gallery
+                </Link>
+                <Link
+                  href="/"
+                  className="flex-1 inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-medium border border-gray-700 text-gray-300 hover:bg-[#1A1A1D] transition"
+                >
+                  Return home
+                </Link>
+              </div>
+            </div>
           </div>
         </div>
       </div>
     </div>
   );
-} 
+}

--- a/src/app/credits/success/page.tsx
+++ b/src/app/credits/success/page.tsx
@@ -87,18 +87,13 @@ function SuccessContent() {
                 {creditCount} credits have been added to your account.
               </p>
             )}
-            <div className="pt-4 space-y-3">
+            <div className="pt-4 space-y-3 text-center text-gray-300">
+              <p>Your balance will update automatically once processing is complete.</p>
               <Link
                 href="/gallery"
                 className="block w-full py-3 px-6 rounded-xl text-white bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF] text-center font-medium hover:opacity-90 transition"
               >
                 Go to your gallery
-              </Link>
-              <Link
-                href="/credits"
-                className="block w-full py-3 px-6 rounded-xl text-white bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF] text-center font-medium hover:opacity-90 transition"
-              >
-                Check my balance
               </Link>
               <Link
                 href="/"
@@ -122,12 +117,9 @@ function SuccessContent() {
               If you believe this is an error, please contact support.
             </p>
             <div className="pt-4 space-y-3">
-              <Link
-                href="/credits"
-                className="block w-full py-3 px-6 rounded-xl text-white bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF] text-center font-medium hover:opacity-90 transition"
-              >
-                Try again
-              </Link>
+              <p className="text-center text-gray-300">
+                Credit purchases are currently disabled. If funds were deducted, please contact support with your payment details.
+              </p>
               <Link
                 href="/"
                 className="block w-full py-3 px-6 border border-gray-600 text-gray-300 text-center rounded-xl hover:bg-[#1A1A1D] transition"

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,7 +3,7 @@
 import useSWR from 'swr';
 import { useRouter, usePathname } from 'next/navigation';
 import Link from 'next/link';
-import { Zap, ChevronRight, LogOut, Menu, X } from 'lucide-react';
+import { Zap, LogOut, Menu, X } from 'lucide-react';
 import { useState, useEffect, useRef } from 'react';
 import Logo from './Logo';
 
@@ -132,19 +132,14 @@ export default function Navbar() {
           <div className="hidden md:flex md:items-center">
             {user && (
               <div className="flex items-center space-x-4">
-                <Link
-                  href="/credits"
-                  className="flex items-center gap-1 bg-black hover:bg-gray-800 px-3 h-10 rounded-full transition-colors group"
-                  onClick={() => mutate()}
-                >
+                <div className="flex items-center gap-1 bg-black px-3 h-10 rounded-full">
                   <Zap size={16} className="text-[#3EFFE2]" />
                   <span className="text-sm font-medium text-white">
                     {user.credits || 0} credits
                   </span>
-                  <ChevronRight size={14} className="text-gray-400 group-hover:text-white transition-colors" />
-                </Link>
-                <div 
-                  className="relative ml-3" 
+                </div>
+                <div
+                  className="relative ml-3"
                   ref={userMenuRef}
                   onMouseEnter={openUserMenu}
                   onMouseLeave={closeUserMenuWithDelay}
@@ -172,13 +167,9 @@ export default function Navbar() {
                       <div className="px-4 py-2 text-sm font-medium text-gray-400 truncate border-b border-gray-700">
                         {user.email}
                       </div>
-                      <Link
-                        href="/credits"
-                        className="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-900"
-                        onClick={() => mutate()}
-                      >
-                        Buy Credits
-                      </Link>
+                      <div className="px-4 py-2 text-sm text-gray-500">
+                        Credit purchases unavailable
+                      </div>
                       <button
                         onClick={async () => {
                           // Sign out via API and redirect to login (full reload)
@@ -207,12 +198,14 @@ export default function Navbar() {
               >
                 Sign In
               </Link>
-              <Link
-                href="/register"
-                className="px-3 py-2 rounded-md text-sm font-medium bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF] text-white hover:opacity-90 transition"
+              <button
+                type="button"
+                disabled
+                title="Sign ups are currently disabled"
+                className="px-3 py-2 rounded-md text-sm font-medium bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF] text-white opacity-50 cursor-not-allowed"
               >
                 Sign Up
-              </Link>
+              </button>
             </div>
           )}
           </div>
@@ -270,14 +263,10 @@ export default function Navbar() {
                 </div>
               </div>
               <div className="mt-3 px-2 space-y-1">
-                <Link
-                  href="/credits"
-                  className="block px-3 py-2 rounded-md text-base font-medium text-gray-400 hover:text-white hover:bg-gray-700 flex items-center"
-                  onClick={closeMenu}
-                >
+                <div className="px-3 py-2 rounded-md text-base font-medium text-gray-500 flex items-center">
                   <Zap className="mr-2 h-5 w-5" />
-                  Buy Credits
-                </Link>
+                  Purchases unavailable
+                </div>
                 <button
                   onClick={async () => {
                     // Sign out via API and redirect to login (full reload)
@@ -307,13 +296,14 @@ export default function Navbar() {
                 >
                   Sign In
                 </Link>
-                <Link
-                  href="/register"
-                  className="block px-3 py-2 rounded-md text-base font-medium text-white bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF] hover:opacity-90 transition"
-                  onClick={closeMenu}
+                <button
+                  type="button"
+                  disabled
+                  title="Sign ups are currently disabled"
+                  className="block w-full px-3 py-2 rounded-md text-base font-medium text-white bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF] opacity-50 cursor-not-allowed"
                 >
                   Sign Up
-                </Link>
+                </button>
               </div>
             </div>
           )}

--- a/src/components/v2/AuthPages.tsx
+++ b/src/components/v2/AuthPages.tsx
@@ -41,6 +41,7 @@ export default function AuthPagesV2({ mode, searchParams }: AuthPagesV2Props) {
   const [isGoogleLoading, setIsGoogleLoading] = useState(false);
 
   const isLogin = mode === 'login';
+  const isRegistrationDisabled = !isLogin;
   const [redirectUrl, setRedirectUrl] = useState<string>('/');
   
   // Check for OAuth errors and redirect parameter
@@ -80,6 +81,11 @@ export default function AuthPagesV2({ mode, searchParams }: AuthPagesV2Props) {
   });
 
   const onSubmit = async (data: Record<string, string>) => {
+    if (!isLogin) {
+      toast.error('New account sign-ups are currently disabled.');
+      return;
+    }
+
     setIsLoading(true);
     try {
       const endpoint = isLogin ? '/api/login' : '/api/register';
@@ -130,6 +136,11 @@ export default function AuthPagesV2({ mode, searchParams }: AuthPagesV2Props) {
   };
 
   const handleGoogleSignIn = async () => {
+    if (!isLogin) {
+      toast.error('New account sign-ups are currently disabled.');
+      return;
+    }
+
     setIsGoogleLoading(true);
     try {
       // Store redirect URL in session storage for OAuth callback
@@ -175,12 +186,12 @@ export default function AuthPagesV2({ mode, searchParams }: AuthPagesV2Props) {
             </p>
           </div>
 
-          {/* Free credits highlight for register */}
+          {/* Registration status */}
           {!isLogin && (
-            <div className="mb-8 p-4 bg-gradient-to-r from-[#3EFFE2]/10 to-[#1E3AFF]/10 border border-[#3EFFE2]/20 rounded-2xl">
-              <div className="text-center">
-                <div className="text-[#3EFFE2] font-semibold mb-1">🎉 Welcome Bonus</div>
-                <div className="text-white text-sm">Get 5 free credits when you sign up</div>
+            <div className="mb-8 p-4 bg-gradient-to-r from-[#FF497D]/10 to-[#A53FFF]/10 border border-[#FF497D]/20 rounded-2xl">
+              <div className="text-center space-y-1">
+                <div className="text-[#FF497D] font-semibold">Sign-ups unavailable</div>
+                <div className="text-white text-sm">New account registration is currently disabled. Please check back later.</div>
               </div>
             </div>
           )}
@@ -312,11 +323,11 @@ export default function AuthPagesV2({ mode, searchParams }: AuthPagesV2Props) {
             {/* Submit button */}
             <button
               type="submit"
-              disabled={isLoading}
+              disabled={isLoading || isRegistrationDisabled}
               className="w-full py-3 px-6 bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF] rounded-xl text-white font-semibold transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl hover:shadow-[#FF497D]/25 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none"
             >
-              {isLoading 
-                ? (isLogin ? 'Signing in...' : 'Creating account...') 
+              {isLoading
+                ? (isLogin ? 'Signing in...' : 'Creating account...')
                 : (isLogin ? 'Sign In' : 'Create Account')
               }
             </button>
@@ -334,7 +345,7 @@ export default function AuthPagesV2({ mode, searchParams }: AuthPagesV2Props) {
 
           <button
             onClick={handleGoogleSignIn}
-            disabled={isLoading || isGoogleLoading}
+            disabled={isLoading || isGoogleLoading || isRegistrationDisabled}
             className="w-full py-3 px-6 bg-[#0D0D0E] border border-[#2A2A2D] rounded-xl text-white font-semibold transition-all duration-300 hover:bg-[#2A2A2D] hover:border-[#3A3A3D] disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-3"
           >
             <Chrome size={20} />
@@ -346,17 +357,12 @@ export default function AuthPagesV2({ mode, searchParams }: AuthPagesV2Props) {
             {isLogin ? (
               <>
                 Don&apos;t have an account?{' '}
-                <Link 
-                  href="/register" 
-                  className="text-[#FF497D] hover:text-[#A53FFF] transition-colors font-medium"
-                >
-                  Sign up
-                </Link>
+                <span className="text-gray-500">Sign ups are currently disabled.</span>
               </>
             ) : (
               <>
                 Already have an account?{' '}
-                <Link 
+                <Link
                   href="/login" 
                   className="text-[#FF497D] hover:text-[#A53FFF] transition-colors font-medium"
                 >

--- a/src/components/v2/GalleryScreen.tsx
+++ b/src/components/v2/GalleryScreen.tsx
@@ -8,7 +8,6 @@ import axios from 'axios';
 import toast from 'react-hot-toast';
 import GIFGeneratorV2 from './GIFGenerator';
 import GalleryGridV2 from './GalleryGrid';
-import CreditsPurchaseV2 from './CreditsPurchase';
 import Navbar from '../Navbar';
 import { UserInfoSkeleton } from '@/components/ui/Skeleton';
 import { useKeyboardShortcuts, globalShortcuts } from '@/hooks/useKeyboardShortcuts';
@@ -17,7 +16,6 @@ const axiosFetcher = (url: string) => axios.get(url).then(res => res.data);
 
 export default function GalleryScreenV2() {
   const [isGeneratorOpen, setIsGeneratorOpen] = useState(false);
-  const [showCreditsPurchase, setShowCreditsPurchase] = useState(false);
   const [thumbnailSize, setThumbnailSize] = useState<'small' | 'medium' | 'large'>('medium');
   const [searchQuery, setSearchQuery] = useState('');
   const [filterStatus, setFilterStatus] = useState<'all' | 'completed' | 'processing' | 'failed'>('all');
@@ -55,10 +53,6 @@ export default function GalleryScreenV2() {
       callback: () => searchInputRef.current?.focus(),
     },
     {
-      ...globalShortcuts.credits,
-      callback: () => setShowCreditsPurchase(true),
-    },
-    {
       ...globalShortcuts.help,
       callback: () => setShowShortcutsHelp(true),
     },
@@ -66,7 +60,6 @@ export default function GalleryScreenV2() {
       ...globalShortcuts.escape,
       callback: () => {
         if (showShortcutsHelp) setShowShortcutsHelp(false);
-        else if (showCreditsPurchase) setShowCreditsPurchase(false);
         else if (isGeneratorOpen) setIsGeneratorOpen(false);
       },
     },
@@ -157,12 +150,7 @@ export default function GalleryScreenV2() {
                     <Zap size={14} className="text-[#3EFFE2] sm:w-[18px] sm:h-[18px]" />
                     <span className="text-white text-xs sm:text-base font-medium">{userCredits} credits</span>
                   </div>
-                  <button
-                    onClick={() => setShowCreditsPurchase(true)}
-                    className="px-3 sm:px-4 py-1 sm:py-2 bg-gradient-to-r from-[#FF497D] to-[#A53FFF] text-white rounded-full text-xs sm:text-sm font-medium hover:opacity-90 transition-opacity"
-                  >
-                    Buy Credits
-                  </button>
+                  <span className="text-xs sm:text-sm text-gray-400">Credit purchases unavailable</span>
                 </div>
               ) : (
                 <UserInfoSkeleton />
@@ -313,36 +301,6 @@ export default function GalleryScreenV2() {
           />
         </div>
 
-        {/* Credits Purchase Modal */}
-        {showCreditsPurchase && (
-          <div 
-            className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4 overflow-y-auto"
-            onClick={() => setShowCreditsPurchase(false)}
-          >
-            <div 
-              className="bg-[#1A1A1D] border border-[#2A2A2D] rounded-3xl p-6 max-w-md w-full shadow-2xl my-8 max-h-[calc(100vh-4rem)] overflow-y-auto"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <div className="flex items-center justify-between mb-6 sticky top-0 bg-[#1A1A1D] py-2 -my-2">
-                <h2 className="text-xl font-bold text-white">Buy Credits</h2>
-                <button
-                  onClick={() => setShowCreditsPurchase(false)}
-                  className="text-gray-400 hover:text-white transition-colors p-1"
-                >
-                  ✕
-                </button>
-              </div>
-              <CreditsPurchaseV2 
-                currentCredits={userCredits}
-                onSuccess={() => {
-                  setShowCreditsPurchase(false);
-                  toast.success('Credits purchased successfully!');
-                }}
-              />
-            </div>
-          </div>
-        )}
-
         {/* Keyboard Shortcuts Help Modal */}
         {showShortcutsHelp && (
           <div 
@@ -371,10 +329,6 @@ export default function GalleryScreenV2() {
                 <div className="flex justify-between items-center py-2 border-b border-[#2A2A2D]">
                   <span className="text-gray-300">Search GIFs</span>
                   <kbd className="px-2 py-1 bg-[#2A2A2D] rounded text-white text-sm">/</kbd>
-                </div>
-                <div className="flex justify-between items-center py-2 border-b border-[#2A2A2D]">
-                  <span className="text-gray-300">Buy credits</span>
-                  <kbd className="px-2 py-1 bg-[#2A2A2D] rounded text-white text-sm">⌘ C</kbd>
                 </div>
                 <div className="flex justify-between items-center py-2 border-b border-[#2A2A2D]">
                   <span className="text-gray-300">Show shortcuts</span>

--- a/src/components/v2/LandingPage.tsx
+++ b/src/components/v2/LandingPage.tsx
@@ -37,13 +37,14 @@ export default function LandingPageV2() {
             {/* CTA Buttons */}
             <div className="flex flex-col sm:flex-row gap-4 justify-center items-center pt-8">
               <button
-                onClick={() => router.push('/register')}
-                className="group relative px-8 py-4 bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF] rounded-2xl text-white font-semibold text-lg transition-all duration-300 hover:scale-105 hover:shadow-2xl hover:shadow-[#FF497D]/25"
+                type="button"
+                disabled
+                title="Sign ups are currently disabled"
+                className="group relative px-8 py-4 bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF] rounded-2xl text-white font-semibold text-lg opacity-50 cursor-not-allowed"
               >
                 <span className="relative z-10">Start Creating Free</span>
-                <div className="absolute inset-0 bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF] rounded-2xl blur-xl opacity-0 group-hover:opacity-50 transition-opacity duration-300"></div>
               </button>
-              
+
               <button
                 onClick={() => router.push('/login')}
                 className="px-8 py-4 border-2 border-gray-600 rounded-2xl text-gray-300 font-semibold text-lg hover:border-[#FF497D] hover:text-white transition-all duration-300"
@@ -51,11 +52,11 @@ export default function LandingPageV2() {
                 Sign In
               </button>
             </div>
-            
-            {/* Free credits highlight */}
+
+            {/* Sign-up status message */}
             <div className="inline-flex items-center gap-2 px-6 py-3 bg-[#1A1A1D] border border-[#2A2A2D] rounded-full">
-              <div className="w-3 h-3 bg-[#3EFFE2] rounded-full animate-pulse"></div>
-              <span className="text-[#3EFFE2] font-medium">5 Free Credits • No Card Required</span>
+              <div className="w-3 h-3 bg-[#FF497D] rounded-full animate-pulse"></div>
+              <span className="text-[#FF497D] font-medium">New account sign ups are temporarily unavailable</span>
             </div>
           </div>
         </div>
@@ -208,11 +209,12 @@ export default function LandingPageV2() {
             Join thousands of creators bringing their images to life
           </p>
           <button
-            onClick={() => router.push('/register')}
-            className="group relative px-8 py-4 bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF] rounded-2xl text-white font-semibold text-lg transition-all duration-300 hover:scale-105 hover:shadow-2xl hover:shadow-[#FF497D]/25"
+            type="button"
+            disabled
+            title="Sign ups are currently disabled"
+            className="group relative px-8 py-4 bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF] rounded-2xl text-white font-semibold text-lg opacity-50 cursor-not-allowed"
           >
             <span className="relative z-10">Start Creating Now</span>
-            <div className="absolute inset-0 bg-gradient-to-r from-[#FF497D] via-[#A53FFF] to-[#1E3AFF] rounded-2xl blur-xl opacity-0 group-hover:opacity-50 transition-opacity duration-300"></div>
           </button>
         </div>
       </div>

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -49,7 +49,6 @@ export const globalShortcuts = {
   newGif: { key: 'n', meta: true, description: 'Create new GIF' },
   search: { key: '/', description: 'Focus search' },
   gallery: { key: 'g', meta: true, description: 'Go to gallery' },
-  credits: { key: 'c', meta: true, description: 'Buy credits' },
   help: { key: '?', shift: true, description: 'Show shortcuts' },
   escape: { key: 'Escape', description: 'Close modal/dialog' },
 };


### PR DESCRIPTION
## Summary
- disable sign-up actions across navigation, landing, and auth pages while surfacing that registration is closed
- remove all user-facing credit purchase affordances, replacing them with availability messaging in the gallery and credits screens
- clean up keyboard shortcuts and related UI that previously triggered credit purchases

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f8534eac28832ba2361b3456c7d957